### PR TITLE
Fix Ukrainian transliteration

### DIFF
--- a/konwert-1.8/filters/UTF8-ascii
+++ b/konwert-1.8/filters/UTF8-ascii
@@ -60,6 +60,16 @@ VARIANT_bg='
 ' VARIANT1_ua='
 	И	Y
 	и	y
+        Щ       Sch
+        щ       sch
+        Г       Gh
+        г       h
+	Й       Y
+	й       i
+        я       ia
+	ю       iu
+	є       ie
+	Ї       Yi
 ' REPLACE='?' MIME=us-ascii
 
 if [ "$FILTERM" = out ]


### PR DESCRIPTION
Some letters were incorrectly transliterated, according to the 1996 official resolution of the Ukrainian Comission on Justice: http://www.brama.com/art/transliterationu.html.